### PR TITLE
fix: Dockerfile에 curl 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN ./gradlew bootJar --no-daemon -x test
 FROM eclipse-temurin:25-jre
 WORKDIR /app
 
-RUN groupadd -r appuser && useradd -r -g appuser appuser
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+  && groupadd -r appuser && useradd -r -g appuser appuser
 
 COPY --from=build /app/build/libs/*.jar app.jar
 


### PR DESCRIPTION
## 개요

헬스체크 실패 원인인 `curl` 미설치 문제를 해결합니다.

Closes #이슈번호

## 변경 사항

Dockerfile Runtime stage에 `curl` 설치 구문 추가

## 변경 이유

`eclipse-temurin:25-jre` 베이스 이미지에 `curl`이 포함되어 있지 않아
컨테이너 헬스체크가 지속 실패하고 `unhealthy` 상태로 표시되는 문제가 있었습니다.

## 테스트

로컬 환경에서 `docker compose up --build` 후 확인

| 컨테이너 | 변경 전 | 변경 후 |
|---|---|---|
| artrun-app | `unhealthy` | `healthy` ✅ |
| artrun-db | `healthy` | `healthy` ✅ |
| artrun-redis | `Up` | `Up` ✅ |